### PR TITLE
Fix camelcase to snakecase function to handle arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leapwallet/buffer-boba",
   "description": "Buffer Boba is a library for decoding protocol buffers in the cosmos ecosystem.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "repository": "https://github.com/leapwallet/buffer-boba",
   "author": "Leap Wallet",
   "license": "MIT",

--- a/src/util.ts
+++ b/src/util.ts
@@ -17,8 +17,15 @@ export const convertObjectCasingFromCamelToSnake = (
   const msgKeys = Object.keys(record)
   const convertedMsg = msgKeys.reduce((acc, key) => {
     const convertedKey = convertCamelCaseToSnakeCase(key)
-    const value = record[key]
-    if (typeof value === 'object' && value !== null) {
+    const value = record[key] 
+
+    if(Array.isArray(value)){
+      return {
+        ...acc,
+        [convertedKey]: value.map(element => convertObjectCasingFromCamelToSnake(element))
+      }
+    }
+    if (typeof value === 'object' && value !== null) { 
       return {
         ...acc,
         [convertedKey]: convertObjectCasingFromCamelToSnake(value)


### PR DESCRIPTION
Currently this function converts arrays in an object to object

e.g

```Typescript

const obj = {
  propOne: [{ aA: 1, bB: 2 }]
}
// expected
const obj = {
  prop_one: [{ a_A: 1, b_B: 2 }]
}

// current behaviour
const obj = {
  prop_one: {0: { a_A: 1, b_B: 2 }}
}

```