### PR TITLE
fix type declaration files overwrite

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@leapwallet/buffer-boba",
   "description": "Buffer Boba is a library for decoding protocol buffers in the cosmos ecosystem.",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "repository": "https://github.com/leapwallet/buffer-boba",
   "author": "Leap Wallet",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "run-s build:types build:lib",
+    "build": "run-s build:lib build:types",
     "build:lib": "vite build",
     "build:types": "tsc",
     "lint": "eslint src",


### PR DESCRIPTION
With recent changes in the build command, the type declaration files were being overwritten by vite. This caused `Could not find a declaration file for module '@leapwallet/buffer-boba'` errors on projects using this library. This PR fixes it.